### PR TITLE
fixed a mismatch in config section name between setup and pagerduty.py

### DIFF
--- a/bin/pagerduty_setup.py
+++ b/bin/pagerduty_setup.py
@@ -31,7 +31,7 @@ class ConfigPagerDutyApp(splunk.admin.MConfigHandler):
         if self.callerArgs.data['service_api_key'][0] in [None, '']:
             self.callerArgs.data['service_api_key'][0] = ''
 
-        self.writeConf('pagerduty', 'pagerduty_api', self.callerArgs.data)
+        self.writeConf('pagerduty', 'service_api', self.callerArgs.data)
         install_pagerduty_py(os.environ.get('SPLUNK_HOME'))
 
 


### PR DESCRIPTION
When running pagerduty.py, the following error was produced:

```
Traceback (most recent call last):
  File "/opt/splunk/bin/scripts/pagerduty.py", line 159, in <module>
     main()
  File "/opt/splunk/bin/scripts/pagerduty.py", line 141, in main
    service_api_key = get_service_api_key(config_file)
  File "/opt/splunk/bin/scripts/pagerduty.py", line 129, in get_service_api_key
    return config.get('service_api', 'service_api_key')
  File "/usr/lib/python2.6/ConfigParser.py", line 532, in get
    raise NoSectionError(section)
ConfigParser.NoSectionError: No section: 'service_api'
```
