### PR TITLE
pagerduty.py script fails when saved search results do not contain "_raw" field

### DIFF
--- a/bin/pagerduty.py
+++ b/bin/pagerduty.py
@@ -149,7 +149,8 @@ def main():
         details['events'].append(event)
 
     # This description could be any field in your event.
-    description = os.environ.get('SPLUNK_ARG_5', details['events'][0]['_raw'])
+    default_description = details['events'][0]['_raw'] if details['events'][0].has_key('_raw') else ''
+    description = os.environ.get('SPLUNK_ARG_5', default_description)
     trigger_pagerduty(description, details, pagerduty_api_key)
 
 


### PR DESCRIPTION
Using version 1.1.0 of the app, I could not get the script failed to create incidents when triggered by a search whose results did not contain the `_raw` field; e.g. a search that pipes results through the `top` or `stats` Splunk commands.  I modified the script to log exceptions thrown by `main()` to a separate log file, and got this:

```
Traceback (most recent call last):
  File "/mnt/splunk-datastore/splunkhome/bin/scripts/pagerduty.py", line 163, in <module>
    main()
  File "/mnt/splunk-datastore/splunkhome/bin/scripts/pagerduty.py", line 155, in main
    description = os.environ.get('SPLUNK_ARG_5', details['events'][0]['_raw'])
KeyError: '_raw'
```

Wether or not the `SPLUNK_ARG_5` environment variable is defined, the expression `details['events'][0]['_raw']` is evaluated.
